### PR TITLE
Allow upstream resolvers to include an explicit port via JSON

### DIFF
--- a/test/spartan_SUITE.erl
+++ b/test/spartan_SUITE.erl
@@ -131,4 +131,5 @@ zk_test(_Config) ->
 %% @private
 %% @doc Use the Spartan resolver.
 resolver_options() ->
-    [{nameservers, [{{127,0,0,1}, 8053}]}].
+    LocalResolver = "127.0.0.1:8053",
+    [{nameservers, [spartan_app:parse_ipv4_address_with_port(LocalResolver, 53)]}].


### PR DESCRIPTION
This extends the IPv4 parsing with support for ports in the JSON config. The result is the same IP/Port pair that is used in the configured application environment.