### PR TITLE
Start the Spartan TCP listener prior to starting the backing supervis…

### DIFF
--- a/src/spartan_app.erl
+++ b/src/spartan_app.erl
@@ -31,8 +31,8 @@
 
 start(_StartType, _StartArgs) ->
     maybe_load_json_config(), %% Maybe load the relevant DCOS configuration
-    Ret = spartan_sup:start_link(),
     maybe_start_tcp_listener(),
+    Ret = spartan_sup:start_link(),
     Ret.
 
 stop(_State) ->


### PR DESCRIPTION
…or -- this can lead to a race condition, where the TCP listener is up, but the backend isn't up yet, causing some ranch acceptors to crash.