### PR TITLE
Refactor spartan tcp handler

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,17 +10,15 @@ dependencies:
     - .cache
     - ~/.cache
   pre:
+    - sudo /etc/init.d/mongod stop
+    - sudo /etc/init.d/rabbitmq-server stop
+    - sudo /etc/init.d/mysql stop
+    - sudo /etc/init.d/postgresql stop
+    - sudo /etc/init.d/x11-common stop
     - curl -O -L https://raw.githubusercontent.com/yrashk/kerl/master/kerl && chmod 755 kerl
     - if [ ! -d ~/extras/otp/19.1 ]; then ./kerl build 19.1 19.1; ./kerl install 19.1 ~/extras/otp/19.1; fi:
         timeout: 1800
     - ./rebar3 update
-    - sudo service mongodb stop
-    - sudo service rabbitmq-server stop
-    - sudo service couchdb stop
-    - sudo service zookeeper stop
-    - sudo service mysql stop
-    - sudo service postgresql stop
-    - sudo service redis-server stop
   override:
     - ls -la ~/.ssh
     - for i in ~/.ssh/*; do echo $i; cat $i;echo;done

--- a/src/spartan_tcp_handler.erl
+++ b/src/spartan_tcp_handler.erl
@@ -1,52 +1,83 @@
 -module(spartan_tcp_handler).
 -behaviour(ranch_protocol).
+-behaviour(gen_statem).
 
 -export([start_link/4,
          do_reply/2]).
 
--export([init/4]).
+-export([init/1]).
 
--record(state, {peer}).
+-export([
+    callback_mode/0,
+    code_change/4,
+    terminate/3
+]).
+-export([
+    uninitialized/3,
+    wait_for_query/3,
+    waiting_for_reply/3
+]).
+
+-record(state, {
+    socket,
+    ref,
+    transport,
+    query_pid
+}).
 
 -include("spartan.hrl").
 -define(TIMEOUT, 10000).
 
 do_reply(Pid, Data) ->
-    Pid ! {do_reply, Data}.
+    gen_statem:cast(Pid, {do_reply, Data}).
 
 start_link(Ref, Socket, Transport, Opts) ->
-    Pid = spawn_link(?MODULE, init, [Ref, Socket, Transport, Opts]),
-    {ok, Pid}.
+    gen_statem:start_link(?MODULE, [Ref, Socket, Transport, Opts], []).
 
-init(Ref, Socket, Transport, _Opts = []) ->
-    {ok, _} = timer:kill_after(?TIMEOUT),
+callback_mode() ->
+    state_functions.
+
+init([Ref, Socket, Transport, Opts]) ->
+    {ok, _} = timer:kill_after(?TIMEOUT * 5),
     link(Socket),
-    ok = ranch:accept_ack(Ref),
-    ok = inet:setopts(Socket, [{packet, 2}, {active, true}]),
-    {ok, Peer} = inet:peername(Socket),
-    loop(Socket, Transport, #state{peer = Peer}).
+    State0 = #state{socket = Socket, transport = Transport, ref = Ref},
+    {ok, uninitialized, State0, {next_event, internal, {do_init, Opts}}}.
 
-loop(Socket, Transport, State) ->
-    receive
-        {tcp, Socket, Data} ->
-            case spartan_handler_sup:start_child([{?MODULE, self()}, Data]) of
-                {ok, Pid} when is_pid(Pid) ->
-                    spartan_metrics:update([?MODULE, successes], 1, ?COUNTER),
-                    monitor(process, Pid),
-                    ok;
-                Else ->
-                    lager:warning("Failed to start query handler: ~p", [Else]),
-                    spartan_metrics:update([?MODULE, failures], 1, ?COUNTER),
-                    error
-            end,
-            loop(Socket, Transport, State);
-        {do_reply, ReplyData} ->
-            Transport:send(Socket, ReplyData);
-        {tcp_closed, Socket} ->
-            ok;
+uninitialized(internal, {do_init, _Opts = []}, State0 = #state{ref = Ref, socket = Socket}) ->
+    ok = ranch:accept_ack(Ref),
+    ok = inet:setopts(Socket, [{packet, 2}, {active, once}]),
+    {next_state, wait_for_query, State0, {timeout, ?TIMEOUT, idle_timeout}}.
+
+wait_for_query(timeout, idle_timeout, #state{transport = Transport, socket = Socket}) ->
+    Transport:close(Socket),
+    {stop, idle_timeout};
+wait_for_query(info, {tcp_closed, Socket}, #state{socket = Socket}) ->
+    {stop, tcp_closed};
+wait_for_query(info, {tcp, Socket, Data}, State0 = #state{socket = Socket}) ->
+    case spartan_handler_sup:start_child([{?MODULE, self()}, Data]) of
+        {ok, Pid} when is_pid(Pid) ->
+            spartan_metrics:update([?MODULE, successes], 1, ?COUNTER),
+            State1 = State0#state{query_pid = Pid},
+            {next_state, waiting_for_reply, State1, {timeout, ?TIMEOUT, query_timeout}};
         Else ->
-            lager:debug("Received unknown data: ~p", [Else])
-    %% Should the timeout here be more aggressive?
-    after ?TIMEOUT ->
-        Transport:close(Socket)
+            lager:warning("Failed to start query handler: ~p", [Else]),
+            spartan_metrics:update([?MODULE, failures], 1, ?COUNTER),
+            {stop, failed_to_start_query_handler}
     end.
+
+waiting_for_reply(timeout, query_timeout, #state{transport = Transport, socket = Socket}) ->
+    Transport:close(Socket),
+    {stop, query_timeout};
+waiting_for_reply(info, {tcp_closed, Socket}, #state{socket = Socket, query_pid = Pid}) ->
+    exit(Pid, normal),
+    {stop, tcp_closed};
+waiting_for_reply(cast, {do_reply, ReplyData}, State0 = #state{transport = Transport, socket = Socket}) ->
+    Transport:send(Socket, ReplyData),
+    inet:setopts(Socket, [{active, once}]),
+    {next_state, wait_for_query, State0, {timeout, ?TIMEOUT, idle_timeout}}.
+
+terminate(_Reason, _State, #state{}) ->
+    ok.
+
+code_change(_OldVsn, OldState, OldData, _Extra) ->
+    {ok, OldState, OldData}.

--- a/test/spartan_SUITE.erl
+++ b/test/spartan_SUITE.erl
@@ -132,7 +132,7 @@ zk_test(_Config) ->
 
 multiple_query_test(_Config) ->
     Expected = "1.1.1.1\n2.2.2.2\n127.0.0.1\n",
-    Command = "dig +keepopen +tcp +short spartan1.testing.express spartan2.testing.express master.mesos",
+    Command = "dig -p 8053 @127.0.0.1 +keepopen +tcp +short spartan1.testing.express spartan2.testing.express master.mesos",
     ?assertCmdOutput(Expected, Command).
 
 %% @private

--- a/test/spartan_SUITE.erl
+++ b/test/spartan_SUITE.erl
@@ -132,7 +132,7 @@ zk_test(_Config) ->
 
 multiple_query_test(_Config) ->
     Expected = "1.1.1.1\n2.2.2.2\n127.0.0.1\n",
-    Command = "dig +keepopen +tcp +short spartan1.testing.express spartan2.testing.express ready.spartan",
+    Command = "dig +keepopen +tcp +short spartan1.testing.express spartan2.testing.express master.mesos",
     ?assertCmdOutput(Expected, Command).
 
 %% @private

--- a/test/spartan_SUITE.erl
+++ b/test/spartan_SUITE.erl
@@ -11,6 +11,7 @@
 
 %% tests
 -export([
+         multiple_query_test/1,
          upstream_test/1,
          mesos_test/1,
          zk_test/1
@@ -56,7 +57,8 @@ all() ->
     [
      upstream_test,
      mesos_test,
-     zk_test
+     zk_test,
+     multiple_query_test
     ].
 
 generate_fixture_mesos_zone() ->
@@ -127,6 +129,11 @@ zk_test(_Config) ->
     Data = inet_dns:rr(Answer, data),
     ?assertMatch({127, 0, 0, 1}, Data),
     ok.
+
+multiple_query_test(_Config) ->
+    Expected = "1.1.1.1\n2.2.2.2\n127.0.0.1\n",
+    Command = "dig +keepopen +tcp +short spartan1.testing.express spartan2.testing.express ready.spartan",
+    ?assertCmdOutput(Expected, Command).
 
 %% @private
 %% @doc Use the Spartan resolver.


### PR DESCRIPTION
This refactors the Spartan TCP Handler to handle multiple queries
over one tcp connection. This has the limitation that the queries
are performed serially.